### PR TITLE
Remove db.wpbl.info

### DIFF
--- a/rblcheck.sh
+++ b/rblcheck.sh
@@ -40,9 +40,6 @@ cbl.abuseat.org
 # Combined DNSBL listing IPs with Hacking activities, Hijacked webserver,
 # Referer spam.
 combined.abuse.ch
-# WPBL is a private block list consisting of IP addresses which connect to
-# members' systems and deliver unsolicited bulk mail (spam)
-db.wpbl.info
 # UCEPROTECT Network, Level 1 lists single IP's only; Level 2 escalates within;
 # allocation; Level 3 lists IP Space of the worst ASN's.
 dnsbl-1.uceprotect.net


### PR DESCRIPTION
The WPBL shut down in 2024, but still receives roughly 57 million queries a day (through old configurations). Using the best practices suggested in RFC 6471, the WPBL operator is peforming a graceful termination of the service.

The WPBL nameservers now point to dummy TEST-NET addresses which will result in lookup errors and timeouts. Please remove WPBL from your configuration files.